### PR TITLE
Add Safari extension scraper and tests

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,7 @@ from database.manager import DatabaseManager
 from scrapers.chrome import ChromeStoreScraper
 from scrapers.firefox import FirefoxAddonsScraper
 from scrapers.edge import EdgeAddonsScraper
+from scrapers.safari import SafariExtensionsScraper
 from config import get_config
 
 # Configure logging
@@ -61,7 +62,8 @@ db_manager = DatabaseManager()
 scrapers = {
     'chrome': ChromeStoreScraper(),
     'firefox': FirefoxAddonsScraper(),
-    'edge': EdgeAddonsScraper()
+    'edge': EdgeAddonsScraper(),
+    'safari': SafariExtensionsScraper(),
 }
 
 # API key validation decorator
@@ -108,7 +110,7 @@ def search_extension():
         return jsonify({'error': 'Invalid JSON data'}), 400
     
     extension_id = data.get('extension_id', '').strip()
-    stores = data.get('stores', ['chrome', 'firefox', 'edge'])
+    stores = data.get('stores', ['chrome', 'firefox', 'edge', 'safari'])
     
     if not extension_id:
         return jsonify({'error': 'Extension ID is required'}), 400
@@ -171,7 +173,7 @@ def bulk_search_extensions():
         return jsonify({'error': 'Invalid JSON data'}), 400
     
     extension_ids = data.get('extension_ids', [])
-    stores = data.get('stores', ['chrome', 'firefox', 'edge'])
+    stores = data.get('stores', ['chrome', 'firefox', 'edge', 'safari'])
     
     if not extension_ids:
         return jsonify({'error': 'Extension IDs are required'}), 400

--- a/backend/scrapers/__init__.py
+++ b/backend/scrapers/__init__.py
@@ -4,5 +4,11 @@ Browser extension scrapers package
 from scrapers.chrome import ChromeStoreScraper
 from scrapers.firefox import FirefoxAddonsScraper
 from scrapers.edge import EdgeAddonsScraper
+from scrapers.safari import SafariExtensionsScraper
 
-__all__ = ['ChromeStoreScraper', 'FirefoxAddonsScraper', 'EdgeAddonsScraper']
+__all__ = [
+    'ChromeStoreScraper',
+    'FirefoxAddonsScraper',
+    'EdgeAddonsScraper',
+    'SafariExtensionsScraper',
+]

--- a/backend/scrapers/safari.py
+++ b/backend/scrapers/safari.py
@@ -1,0 +1,75 @@
+"""
+Safari App Store scraper using iTunes Search API
+"""
+import logging
+from typing import Optional
+
+from scrapers.base import ExtensionScraper
+from models.extension import ExtensionData
+
+logger = logging.getLogger(__name__)
+
+
+class SafariExtensionsScraper(ExtensionScraper):
+    """Safari App Store scraper"""
+
+    def __init__(self):
+        super().__init__()
+        self.store_name = "safari"
+        # Use a Safari-like user agent
+        self.session.headers.update({
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15"
+            )
+        })
+
+    def validate_id(self, extension_id: str) -> bool:
+        """Safari extensions use numeric IDs from the App Store"""
+        return extension_id.isdigit()
+
+    def normalize_id(self, extension_id: str) -> str:
+        """IDs are numeric; simply strip whitespace"""
+        return extension_id.strip()
+
+    def get_extension_url(self, extension_id: str) -> str:
+        """Return the public App Store URL"""
+        return f"https://apps.apple.com/us/app/id{extension_id}"
+
+    def scrape(self, extension_id: str) -> Optional[ExtensionData]:
+        """Scrape extension data from the App Store"""
+        if not self.validate_id(extension_id):
+            logger.warning(f"Invalid Safari extension ID format: {extension_id}")
+            return self.create_not_found_result(extension_id)
+
+        normalized_id = self.normalize_id(extension_id)
+        api_url = f"https://itunes.apple.com/lookup?id={normalized_id}&country=us"
+
+        try:
+            logger.info(f"Scraping Safari extension: {normalized_id}")
+            response = self.session.get(api_url, timeout=self.timeout)
+            response.raise_for_status()
+            data = response.json()
+
+            if data.get("resultCount", 0) == 0:
+                return self.create_not_found_result(normalized_id)
+
+            result = data["results"][0]
+            ext_data = ExtensionData(
+                extension_id=normalized_id,
+                name=result.get("trackName", ""),
+                publisher=result.get("sellerName", ""),
+                description=result.get("description", "")[:500],
+                version=result.get("version", ""),
+                rating=str(result.get("averageUserRating", "")),
+                rating_count=str(result.get("userRatingCount", "")),
+                last_updated=result.get("currentVersionReleaseDate", ""),
+                store_source=self.store_name,
+                store_url=result.get("trackViewUrl", self.get_extension_url(normalized_id)),
+                icon_url=result.get("artworkUrl100", ""),
+                found=True,
+            )
+            return ext_data
+
+        except Exception as e:
+            return self.handle_request_error(normalized_id, e)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,11 +27,26 @@ def test_health_check(client):
 
 def test_search_extension(client):
     """Test search endpoint"""
-    response = client.post('/api/search',
-                          json={
-                              'extension_id': 'cjpalhdlnbpafiamejdnhcphjbkeiagm',
-                              'stores': ['chrome']
-                          })
+    response = client.post(
+        '/api/search',
+        json={
+            'extension_id': 'cjpalhdlnbpafiamejdnhcphjbkeiagm',
+            'stores': ['chrome', 'safari']
+        }
+    )
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert 'extension_id' in data
+    assert 'results' in data
+    assert isinstance(data['results'], list)
+
+
+def test_search_extension_safari(client):
+    """Test search endpoint for Safari store"""
+    response = client.post(
+        '/api/search',
+        json={'extension_id': 'invalid', 'stores': ['safari']}
+    )
     assert response.status_code == 200
     data = json.loads(response.data)
     assert 'extension_id' in data
@@ -48,11 +63,24 @@ def test_search_invalid_request(client):
 
 def test_bulk_search(client):
     """Test bulk search endpoint"""
-    response = client.post('/api/bulk-search',
-                          json={
-                              'extension_ids': ['cjpalhdlnbpafiamejdnhcphjbkeiagm'],
-                              'stores': ['chrome']
-                          })
+    response = client.post(
+        '/api/bulk-search',
+        json={
+            'extension_ids': ['cjpalhdlnbpafiamejdnhcphjbkeiagm'],
+            'stores': ['chrome', 'safari']
+        }
+    )
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert 'results' in data
+
+
+def test_bulk_search_safari(client):
+    """Test bulk search with Safari store"""
+    response = client.post(
+        '/api/bulk-search',
+        json={'extension_ids': ['invalid'], 'stores': ['safari']}
+    )
     assert response.status_code == 200
     data = json.loads(response.data)
     assert 'results' in data

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'backend'))
 from scrapers.chrome import ChromeStoreScraper
 from scrapers.firefox import FirefoxAddonsScraper
 from scrapers.edge import EdgeAddonsScraper
+from scrapers.safari import SafariExtensionsScraper
 import json
 
 # Test extension IDs
@@ -27,7 +28,12 @@ TEST_IDS = {
         'odfafepnkmbhccpbejgmiehpchacaeak',  # uBlock Origin (Edge)
         'ndcileolkflehcjpmjnfbnaibdcgglog',  # Bitwarden
         'INVALIDEDGEEXTENSION',               # Invalid ID
-    ]
+    ],
+    'safari': [
+        '1569813296',                         # 1Password for Safari
+        '1440147259',                         # AdGuard for Safari
+        'invalid',                            # Invalid ID
+    ],
 }
 
 def test_scraper(scraper_class, store_name, test_ids):
@@ -75,6 +81,9 @@ def main():
     
     # Test Edge scraper
     test_scraper(EdgeAddonsScraper, "Edge Add-ons", TEST_IDS['edge'])
+
+    # Test Safari scraper
+    test_scraper(SafariExtensionsScraper, "Safari Extensions", TEST_IDS['safari'])
     
     print("\n" + "="*60)
     print("Test complete!")


### PR DESCRIPTION
## Summary
- implement Safari App Store scraper using iTunes Search API
- register Safari scraper in backend and expose via API
- expand scraper and API tests to cover Safari

## Testing
- `python tests/test_scrapers.py`
- `pytest tests/test_api.py`


------
https://chatgpt.com/codex/tasks/task_b_68adb38c802c8323ae3ca76fd45931df